### PR TITLE
新しい質問を「もっと見る」ことができるようにする (issue #48

### DIFF
--- a/board/static/board/new_questions.js
+++ b/board/static/board/new_questions.js
@@ -1,0 +1,9 @@
+Vue.createApp({
+    delimiters: ['[[', ']]'],
+    methods: {
+        fromNowFilter(created_at_RFC5322) {
+            const date = moment(created_at_RFC5322);
+            return date.fromNow(); 
+        }
+    },
+}).mount('#new_questions_app');

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -14,6 +14,9 @@
 
     <div id="main_container" class="container">
         <h1>新しい質問🤗</h1>
+        {% for day_ago in days_ago %}
+                                {{ day_ago }}
+                            {% endfor %}
         <p class="lead">新しい質問を{{ post_list | length }}件表示しています。</p>
         <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
             {% for newpost in post_list %}
@@ -29,6 +32,10 @@
                             </a>
                             <br>
                             投稿日:{{newpost.created_at}}
+                            <br>{{ current_time}}
+                            <br>{{ post_time }}
+                            <br>
+                            <br>{{ days }}
                         </div>
                     </div>
                 </div>

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -11,12 +11,9 @@
 
 <body class="bg-light">
     {% include 'header.html' %}
-
     <div id="main_container" class="container">
         <h1>新しい質問🤗</h1>
-        {% for day_ago in days_ago %}
-                                {{ day_ago }}
-                            {% endfor %}
+        {{ bbb }}
         <p class="lead">新しい質問を{{ post_list | length }}件表示しています。</p>
         <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
             {% for newpost in post_list %}
@@ -31,16 +28,16 @@
                                 {{ newpost.thread.title | truncatechars:30}}
                             </a>
                             <br>
-                            投稿日:{{newpost.created_at}}
-                            <br>{{ current_time}}
-                            <br>{{ post_time }}
-                            <br>
-                            <br>{{ days }}
+                            投稿日:{{newpost.created_at }}
+                            <br>{{ newpost.days_ago }}
                         </div>
                     </div>
                 </div>
             </div>
             {% endfor %}
+            {% for days in aaa %}
+        {{ days }}
+    {% endfor %}
         </div>
         <div class="text-center mt-3 mb-4">
             <a href="{% url 'search' %}">

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -13,7 +13,6 @@
     {% include 'header.html' %}
     <div id="main_container" class="container">
         <h1>新しい質問🤗</h1>
-        {{ bbb }}
         <p class="lead">新しい質問を{{ post_list | length }}件表示しています。</p>
         <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
             {% for newpost in post_list %}
@@ -29,15 +28,11 @@
                             </a>
                             <br>
                             投稿日:{{newpost.created_at }}
-                            <br>{{ newpost.days_ago }}
                         </div>
                     </div>
                 </div>
             </div>
             {% endfor %}
-            {% for days in aaa %}
-        {{ days }}
-    {% endfor %}
         </div>
         <div class="text-center mt-3 mb-4">
             <a href="{% url 'search' %}">

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -14,33 +14,43 @@
     <div id="main_container" class="container">
         <h1>新しい質問🤗</h1>
         <p class="lead">新しい質問を{{ post_list | length }}件表示しています。</p>
-        <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
-            {% for newpost in post_list %}
-            <div class="col">
-                <div class="card bg-white h-100">
-                    <div class="card-body d-flex flex-column justify-content-between">
-                        <p class="card-text" style="overflow-wrap: anywhere;">
-                            {{newpost.text | linebreaksbr}}
-                        </p>
-                        <div class="text-end" style="font-size: 0.5em;">
-                            <a href="{% url 'threads' newpost.thread_id %}" class="card-link">
-                                {{ newpost.thread.title | truncatechars:30}}
-                            </a>
-                            <br>
-                            投稿日:{{newpost.created_at }}
+        <div id="new_questions_app">
+            <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
+                {% for newpost in post_list %}
+                <div class="col">
+                    <div class="card bg-white h-100">
+                        <div class="card-body d-flex flex-column justify-content-between">
+                            <p class="card-text" style="overflow-wrap: anywhere;">
+                                {{newpost.text | linebreaksbr}}
+                            </p>
+                            <div class="text-end" style="font-size: 0.5em;">
+                                <a href="{% url 'threads' newpost.thread_id %}" class="card-link">
+                                    {{ newpost.thread.title | truncatechars:30}}
+                                </a>
+                                <br>
+                                [[ fromNowFilter('{{newpost.created_at | date:"r"}}') ]]
+                            </div>
                         </div>
                     </div>
                 </div>
+                {% endfor %}
             </div>
-            {% endfor %}
         </div>
         <div class="text-center mt-3 mb-4">
             <a href="{% url 'search' %}">
                 トップページに戻る
-            </a>  
+            </a>
         </div>
         {% include 'footer.html' %}
     </div>
 
     {% include 'load_javascript.html' %}
+
+    <!-- load moment.js-->
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.29.4/min/moment.min.js" 
+            integrity="sha256-80OqMZoXo/w3LuatWvSCub9qKYyyJlK0qnUCYEghBx8=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.29.4/locale/ja.js" 
+            integrity="sha256-lyDeRZLdlIYfL6u1ERBTP+RGIPUX5QRI3YKKfy7vcAk=" crossorigin="anonymous"></script>
+
+    <script src="{% static 'board/new_questions.js' %}"></script>
 </body>

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -26,7 +26,9 @@
                         <div class="text-end" style="font-size: 0.5em;">
                             <a href="{% url 'threads' newpost.thread_id %}" class="card-link">
                                 {{ newpost.thread.title | truncatechars:30}}
-                            </a>  
+                            </a>
+                            <br>
+                            投稿日:{{newpost.created_at}}
                         </div>
                     </div>
                 </div>

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -1,0 +1,41 @@
+{% load static %}
+<!doctype html>
+<html lang="ja">
+
+<head>
+    {% include 'html_head.html' %}
+    <title>新しい質問 | A+つくば</title>
+    <meta property="og:title" content="新しい質問 | A+つくば" />
+    <meta property="og:type" content="artcle" />
+</head>
+
+<body class="bg-light">
+    {% include 'header.html' %}
+
+    <div id="main_container" class="container">
+        <h1>新しい質問🤗</h1>
+        <p class="lead">新着の質問を{{ post_list | length }}件表示しています。</p>
+        <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
+            {% for newpost in post_list %}
+            <div class="col">
+                <div class="card bg-white h-100">
+                    <div class="card-body d-flex flex-column justify-content-between">
+                        <p class="card-text" style="overflow-wrap: anywhere;">
+                            {{newpost.text }}
+                        </p>
+                        <div class="text-end">
+                            <a href="{% url 'threads' newpost.thread_id %}" class="card-link">
+                                {{ newpost.thread.title | truncatechars:20}}
+                            </a>  
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
+        {% include 'footer.html' %}
+    </div>
+
+    {% include 'load_javascript.html' %}
+</body>

--- a/board/templates/board/NewQuestions.html
+++ b/board/templates/board/NewQuestions.html
@@ -14,18 +14,18 @@
 
     <div id="main_container" class="container">
         <h1>新しい質問🤗</h1>
-        <p class="lead">新着の質問を{{ post_list | length }}件表示しています。</p>
+        <p class="lead">新しい質問を{{ post_list | length }}件表示しています。</p>
         <div class="row row-cols-1 row-cols-md-4 g-1 card-group">
             {% for newpost in post_list %}
             <div class="col">
                 <div class="card bg-white h-100">
                     <div class="card-body d-flex flex-column justify-content-between">
                         <p class="card-text" style="overflow-wrap: anywhere;">
-                            {{newpost.text }}
+                            {{newpost.text | linebreaksbr}}
                         </p>
-                        <div class="text-end">
+                        <div class="text-end" style="font-size: 0.5em;">
                             <a href="{% url 'threads' newpost.thread_id %}" class="card-link">
-                                {{ newpost.thread.title | truncatechars:20}}
+                                {{ newpost.thread.title | truncatechars:30}}
                             </a>  
                         </div>
                     </div>
@@ -33,7 +33,11 @@
             </div>
             {% endfor %}
         </div>
-
+        <div class="text-center mt-3 mb-4">
+            <a href="{% url 'search' %}">
+                トップページに戻る
+            </a>  
+        </div>
         {% include 'footer.html' %}
     </div>
 

--- a/board/templates/board/Search.html
+++ b/board/templates/board/Search.html
@@ -112,7 +112,14 @@
             <div class="card-group">
               <div class="card">
                 <div class="card-body">
-                  <h5 class="card-title">新しい質問🤗</h5>
+                  <div class="d-flex justify-content-between">
+                    <h5 class="card-title">
+                      新しい質問🤗
+                    </h5>
+                    <span class="text-end">
+                      <a href="{% url 'new_questions' %}" class="btn btn-outline-secondary btn-sm">もっと見る</a>
+                    </span>
+                  </div>
                   <ol class="list-group list-group-flush">
                     {% for newpost in post_list %}
                     <li class="list-group-item">

--- a/board/urls.py
+++ b/board/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('', views.Index.as_view(), name='index'),
     path('threads/<int:thread_id>/', views.ThreadView.as_view(), name='threads'),
     path('search/', views.SearchView.as_view(), name='search'),
+    path('search/new_questions/', views.NewQuestionsView.as_view(), name='new_questions'),
     path('api/get_subthreads', apis.get_subthreads.as_view(), name = "api_get_subthreads"),
     path('api/get_replies', apis.get_replies.as_view(), name = "api_get_replies"),
     path('api/post_subthreads', apis.post_subthreads.as_view(), name = "api_post_subthreadss"),

--- a/board/views.py
+++ b/board/views.py
@@ -4,7 +4,6 @@ from .models import Notice, Post, Reply, Subject, Thread
 from django.shortcuts import redirect
 from django.views.generic import TemplateView, ListView
 from django.db.models import Count
-import datetime
 
 class Index(ListView):
     def get(self, request, *args, **kwargs):

--- a/board/views.py
+++ b/board/views.py
@@ -98,12 +98,14 @@ class NewQuestionsView(ListView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
+        # context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
+        all_objects = self.model.objects.all().order_by('-created_at')[:40]
         current_time = datetime.datetime.now()
         # post_time is created_at
         post_time = []
         for i in range(0, 40):
-            post_time.append(context['post_list'][i].created_at)
+            # post_time.append(context['post_list'][i].created_at)
+            post_time.append(all_objects[i].created_at)
         # post_time = context['post_list'][0].created_at
         # 何日前か計算する
         # current_time is XXXX年XX月XX日XX:XX
@@ -119,10 +121,26 @@ class NewQuestionsView(ListView):
         days_ago = []
         for i in range(0, 40):
             days_ago.append((datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2[i], "%Y/%m/%d")).days)
-        context['days_ago'] = days_ago
+        
+        
+
+        # Added property(name) to all_objects
+        
+
+        for i in range(0, 40):
+            # all_objects[i].days_ago = days_ago[i]
+            all_objects[i].days_ago = 12
+        context['post_list'] = all_objects
+        # all_objects + days_ago
+        # context['post_list'] = zip(all_objects, days_ago)
+        # context['post_list'] =  all_objects
+        # context['post_list'] = zip(all_objects, days_ago)
+
+        context['aaa'] = days_ago
+        all_objects[0].created_at = 12
+        context['bbb'] = all_objects[0].created_at
         # context['days'] = (datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2, "%Y/%m/%d")).days
 
-        context['current_time'] = current_time
-        context['post_time'] = post_time
+        # context['current_time'] = current_time
 
         return context

--- a/board/views.py
+++ b/board/views.py
@@ -98,49 +98,5 @@ class NewQuestionsView(ListView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        # context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
-        all_objects = self.model.objects.all().order_by('-created_at')[:40]
-        current_time = datetime.datetime.now()
-        # post_time is created_at
-        post_time = []
-        for i in range(0, 40):
-            # post_time.append(context['post_list'][i].created_at)
-            post_time.append(all_objects[i].created_at)
-        # post_time = context['post_list'][0].created_at
-        # 何日前か計算する
-        # current_time is XXXX年XX月XX日XX:XX
-        # post_time is XXXX年XX月XX日XX:XX
-        # という形式なので、日付だけを取り出す
-        current_time2 = current_time.strftime("%Y/%m/%d")
-        post_time2 = []
-        for i in range(0, 40):
-            post_time2.append(post_time[i].strftime("%Y/%m/%d"))
-        # post_time2 = post_time.strftime("%Y/%m/%d")
-        # 日付の差を計算する
-        
-        days_ago = []
-        for i in range(0, 40):
-            days_ago.append((datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2[i], "%Y/%m/%d")).days)
-        
-        
-
-        # Added property(name) to all_objects
-        
-
-        for i in range(0, 40):
-            # all_objects[i].days_ago = days_ago[i]
-            all_objects[i].days_ago = 12
-        context['post_list'] = all_objects
-        # all_objects + days_ago
-        # context['post_list'] = zip(all_objects, days_ago)
-        # context['post_list'] =  all_objects
-        # context['post_list'] = zip(all_objects, days_ago)
-
-        context['aaa'] = days_ago
-        all_objects[0].created_at = 12
-        context['bbb'] = all_objects[0].created_at
-        # context['days'] = (datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2, "%Y/%m/%d")).days
-
-        # context['current_time'] = current_time
-
+        context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
         return context

--- a/board/views.py
+++ b/board/views.py
@@ -4,6 +4,7 @@ from .models import Notice, Post, Reply, Subject, Thread
 from django.shortcuts import redirect
 from django.views.generic import TemplateView, ListView
 from django.db.models import Count
+import datetime
 
 class Index(ListView):
     def get(self, request, *args, **kwargs):
@@ -98,4 +99,30 @@ class NewQuestionsView(ListView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
+        current_time = datetime.datetime.now()
+        # post_time is created_at
+        post_time = []
+        for i in range(0, 40):
+            post_time.append(context['post_list'][i].created_at)
+        # post_time = context['post_list'][0].created_at
+        # 何日前か計算する
+        # current_time is XXXX年XX月XX日XX:XX
+        # post_time is XXXX年XX月XX日XX:XX
+        # という形式なので、日付だけを取り出す
+        current_time2 = current_time.strftime("%Y/%m/%d")
+        post_time2 = []
+        for i in range(0, 40):
+            post_time2.append(post_time[i].strftime("%Y/%m/%d"))
+        # post_time2 = post_time.strftime("%Y/%m/%d")
+        # 日付の差を計算する
+        
+        days_ago = []
+        for i in range(0, 40):
+            days_ago.append((datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2[i], "%Y/%m/%d")).days)
+        context['days_ago'] = days_ago
+        # context['days'] = (datetime.datetime.strptime(current_time2, "%Y/%m/%d") - datetime.datetime.strptime(post_time2, "%Y/%m/%d")).days
+
+        context['current_time'] = current_time
+        context['post_time'] = post_time
+
         return context

--- a/board/views.py
+++ b/board/views.py
@@ -89,3 +89,13 @@ class SearchView(ListView):
         context["notice"] = notice
 
         return context
+
+class NewQuestionsView(ListView):
+    """新規投稿一覧を表示するページ"""
+    template_name = "board/NewQuestions.html"
+    model = Post
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['post_list'] = self.model.objects.all().order_by('-created_at')[:40]
+        return context


### PR DESCRIPTION
# 1.「もっと見る」ページの作成
`/search/new_questions/`を作成。

あまり運用としてよくはないんですが、実際のデータで見てみないと塩梅がわからないので、
こっそりデプロイしてあります。
https://www.aplus-tsukuba.net/search/new_questions/

感情を表示するべきなのかなとは思ったのですが
 - 実装コストがやや高い
 - デザインを試行してみたがうまくはまらなかった

のでやってません

# 2.「もっと見る」ページへのリンクの設置
これはデプロイしていません。
![image](https://user-images.githubusercontent.com/40143183/193501652-cdf55853-47f2-4a49-93ce-91229449953f.png)
デザインを割と悩んだのですが、上のような感じで配置してみました。