### PR TITLE
【緊急】axiosのバージョンを1.0.0に固定し、投稿が表示されない不具合を修正する

### DIFF
--- a/board/templates/load_javascript.html
+++ b/board/templates/load_javascript.html
@@ -1,9 +1,8 @@
 {% load static %}
 
 <!-- js-cookie -->
-<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js" 
-  integrity="sha256-0H3Nuz3aug3afVbUlsu12Puxva3CP4EhJtPExqs54Vg=" 
-  crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"
+  integrity="sha256-0H3Nuz3aug3afVbUlsu12Puxva3CP4EhJtPExqs54Vg=" crossorigin="anonymous"></script>
 
 <!-- ITF checking -->
 <script src="{% static 'board/ITFchk.js' %}"></script>
@@ -14,8 +13,7 @@
 
 <!-- Option 1: Bootstrap Bundle with Popper -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-  integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
-  crossorigin="anonymous"></script>
+  integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 
 <!-- Option 2: Separate Popper and Bootstrap JS -->
 <!--
@@ -24,7 +22,8 @@
 -->
 
 <!-- Axios -->
-<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/axios@1.0.0/dist/axios.min.js"
+  integrity="sha256-+jaQh/Y2qcve1H1nPCm9+1r772cFN+2+JUb0ogsCE0c=" crossorigin="anonymous"></script>
 
 <!-- Vue.js 2 DEV VERSION-->
 <!--
@@ -32,6 +31,6 @@
 -->
 
 <!-- Vue.js 3 PROD VERSION-->
-  <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
 
 <script src="{% static 'board/common.js' %}"></script>


### PR DESCRIPTION
axios のバージョンが`1.1.0`にアップデートされ、axiosが正常に動作しなくなる不具合が生じている。
後方互換のないアップデートだったみたい。
https://github.com/axios/axios/issues/5038

CDNからaxiosをロードする際にバージョンを指定していなかったため、アップデートされ不具合が生じた。