### PR TITLE
View Testのテストケース修正

### DIFF
--- a/board/tests/test_views.py
+++ b/board/tests/test_views.py
@@ -34,7 +34,7 @@ class ThreadViewTest(TestCase):
     # 存在しないスレッドにアクセスした時のステータスコードが404か
     def test_thread_view_404(self):
         max_id = Thread.objects.all().aggregate(Max("id"))["id__max"]
-        response = self.client.get(reverse('threads', args=[max_id+1])) # /threads/2/ にアクセス
+        response = self.client.get(reverse('threads', args=[max_id+1])) # /threads/max(thread.id)+1/ にアクセス
         self.assertEqual(response.status_code, 404)
 
     # テンプレートが正しいか

--- a/board/tests/test_views.py
+++ b/board/tests/test_views.py
@@ -130,14 +130,16 @@ class SearchViewTest(TestCase):
 
     # emergency rankingが正しいか
     def test_emergency_ranking(self):
+        thread1 = Thread.objects.get(title="test thread")
         thread3 = Thread.objects.get(title="test thread3")
         post3_2 = Post.objects.create(sender_name="test sender3_2", text="test text3_2", emotion=0, thread=thread3)
         reply3_1 = Reply.objects.create(sender_name="test sender3_3", text="test text3_3", emotion=0, post_id=post3_2)
         response = self.client.get(reverse('search'))
-        self.assertEqual(response.context['ranking'][0][0], 3)
+        # (tid, title, num)
+        self.assertEqual(response.context['ranking'][0][0], thread3.id)
         self.assertEqual(response.context['ranking'][0][1], "test thread3")
         self.assertEqual(response.context['ranking'][0][2], 3)
-        self.assertEqual(response.context['ranking'][1][0], 1)
+        self.assertEqual(response.context['ranking'][1][0], thread1.id)
         self.assertEqual(response.context['ranking'][1][1], "test thread")
         self.assertEqual(response.context['ranking'][1][2], 1)
 

--- a/board/tests/test_views.py
+++ b/board/tests/test_views.py
@@ -17,7 +17,7 @@ class ThreadViewTest(TestCase):
     # テスト用のデータを作成
     def setUp(self) -> None:
         thread = Thread.objects.create(title="test thread")
-        subject = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread)
+        subject = Subject.objects.create(code="TST0001", name="test name", teachers="test teachers", thread_id=thread)
         
         post_created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
         reply_created_at = post_created_at + datetime.timedelta(minutes=1)
@@ -54,7 +54,7 @@ class ThreadViewTest(TestCase):
         self.assertEqual(response.context['thread_id'], 1)
         self.assertEqual(response.context['sub_title'], "test name")
         self.assertEqual(response.context['sub_teachers'], "test teachers")
-        self.assertEqual(response.context['sub_codes'], "test code")
+        self.assertEqual(response.context['sub_codes'], "TST0001")
 
     def test_queryset(self):
         response = self.client.get(reverse('threads', args=[1]))
@@ -97,15 +97,15 @@ class SearchViewTest(TestCase):
     # テスト用のデータを作成
     def setUp(self) -> None:
         thread1 = Thread.objects.create(title="test thread")
-        subject1 = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread1)
+        subject1 = Subject.objects.create(code="TST0001", name="test name", teachers="test teachers", thread_id=thread1)
         post1_created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
         post1 = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread1, created_at=post1_created_at)
         thread2 = Thread.objects.create(title="test thread2")
-        subject2 = Subject.objects.create(code="test code2", name="test name2", teachers="test teachers2", thread_id=thread2)
+        subject2 = Subject.objects.create(code="TST0002", name="test name2", teachers="test teachers2", thread_id=thread2)
         post2_created_at = post1_created_at + datetime.timedelta(seconds=30)
         post2 = Post.objects.create(sender_name="test sender2", text="test text2", emotion=1, thread=thread2, created_at=post2_created_at)
         thread3 = Thread.objects.create(title="test thread3")
-        subject3 = Subject.objects.create(code="test code3", name="test name3", teachers="test teachers3", thread_id=thread3)
+        subject3 = Subject.objects.create(code="TST0003", name="test name3", teachers="test teachers3", thread_id=thread3)
         post3_created_at = post2_created_at + datetime.timedelta(seconds=10)
         post3 = Post.objects.create(sender_name="test sender3", text="test text3", emotion=0, thread=thread3, created_at=post3_created_at)
 
@@ -122,7 +122,7 @@ class SearchViewTest(TestCase):
     # 新しい質問は新しい投稿が上に来るか
     def test_ordering(self):
         thread_new = Thread.objects.create(title="test_new thread")
-        subject_new = Subject.objects.create(code="test_new code", name="test_new name", teachers="test_new teachers", thread_id=thread_new)
+        subject_new = Subject.objects.create(code="TST0004", name="test_new name", teachers="test_new teachers", thread_id=thread_new)
         post_new = Post.objects.create(sender_name="test_new sender", text="test_new text", thread=thread_new)
         response = self.client.get(reverse('search'))
         self.assertEqual(response.context['post_list'][0].text, "test_new text")
@@ -153,7 +153,7 @@ class  NewQuestionsViewTest(TestCase):
         created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
         for i in range(41):
             thread = Thread.objects.create(title="test thread")
-            subject = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread)
+            subject = Subject.objects.create(code=f"TST00{i}", name="test name", teachers="test teachers", thread_id=thread)
             tdelta = datetime.timedelta(minutes=i)
             post = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread, created_at=created_at+tdelta)
         
@@ -170,7 +170,7 @@ class  NewQuestionsViewTest(TestCase):
     # 新しい質問は新しい投稿が上に来るか
     def test_ordering(self):
         thread_new = Thread.objects.create(title="test_new thread")
-        subject_new = Subject.objects.create(code="test_new code", name="test_new name", teachers="test_new teachers", thread_id=thread_new)
+        subject_new = Subject.objects.create(code="TSTNEW01", name="test_new name", teachers="test_new teachers", thread_id=thread_new)
         post_new = Post.objects.create(sender_name="test_new sender", text="test_new text", thread=thread_new)
         response = self.client.get(reverse('new_questions'))
         self.assertEqual(response.context['post_list'][0].text, "test_new text")

--- a/board/tests/test_views.py
+++ b/board/tests/test_views.py
@@ -1,7 +1,10 @@
+import datetime
+import pytz
+
 from django.test import TestCase, Client
 from django.http import HttpRequest
-from board.views import Index, ThreadView, SearchView, NewQuestionsView, AboutView, TermsView, PrivacyView, ServiceWorkerView, GetAppView
 from django.urls import reverse, resolve
+from board.views import Index, ThreadView, SearchView, NewQuestionsView, AboutView, TermsView, PrivacyView, ServiceWorkerView, GetAppView
 from board.models import Thread, Post, Reply, Subject, Notice
 
 class IndexTest(TestCase):
@@ -15,8 +18,12 @@ class ThreadViewTest(TestCase):
     def setUp(self) -> None:
         thread = Thread.objects.create(title="test thread")
         subject = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread)
-        post = Post.objects.create(sender_name="test sender", text="test text", thread=thread)
-        reply = Reply.objects.create(sender_name="test sender", text="test text", post_id=post)
+        
+        post_created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
+        reply_created_at = post_created_at + datetime.timedelta(minutes=1)
+
+        post = Post.objects.create(sender_name="test sender", text="test text", thread=thread, created_at=post_created_at)
+        reply = Reply.objects.create(sender_name="test sender", text="test text", post_id=post, created_at=reply_created_at)
 
     # 存在するスレッドにアクセスした時のステータスコードが200か
     def test_thread_view_200(self):
@@ -91,13 +98,16 @@ class SearchViewTest(TestCase):
     def setUp(self) -> None:
         thread1 = Thread.objects.create(title="test thread")
         subject1 = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread1)
-        post1 = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread1)
+        post1_created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
+        post1 = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread1, created_at=post1_created_at)
         thread2 = Thread.objects.create(title="test thread2")
         subject2 = Subject.objects.create(code="test code2", name="test name2", teachers="test teachers2", thread_id=thread2)
-        post2 = Post.objects.create(sender_name="test sender2", text="test text2", emotion=1, thread=thread2)
+        post2_created_at = post1_created_at + datetime.timedelta(seconds=30)
+        post2 = Post.objects.create(sender_name="test sender2", text="test text2", emotion=1, thread=thread2, created_at=post2_created_at)
         thread3 = Thread.objects.create(title="test thread3")
         subject3 = Subject.objects.create(code="test code3", name="test name3", teachers="test teachers3", thread_id=thread3)
-        post3 = Post.objects.create(sender_name="test sender3", text="test text3", emotion=0, thread=thread3)
+        post3_created_at = post2_created_at + datetime.timedelta(seconds=10)
+        post3 = Post.objects.create(sender_name="test sender3", text="test text3", emotion=0, thread=thread3, created_at=post3_created_at)
 
     # searchページのステータスコードが200か
     def test_search_view(self):
@@ -140,10 +150,12 @@ class SearchViewTest(TestCase):
 class  NewQuestionsViewTest(TestCase):
     # テスト用のデータを作成
     def setUp(self) -> None:
+        created_at = datetime.datetime(2022, 9, 20, 8, 40, 0, 0, pytz.timezone("Asia/Tokyo"))
         for i in range(41):
             thread = Thread.objects.create(title="test thread")
             subject = Subject.objects.create(code="test code", name="test name", teachers="test teachers", thread_id=thread)
-            post = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread)
+            tdelta = datetime.timedelta(minutes=i)
+            post = Post.objects.create(sender_name="test sender", text="test text", emotion=0, thread=thread, created_at=created_at+tdelta)
         
      # NewQuestionsページのステータスコードが200か
     def test_new_questions_view(self):

--- a/board/tests/test_views.py
+++ b/board/tests/test_views.py
@@ -33,7 +33,6 @@ class ThreadViewTest(TestCase):
 
     # 存在しないスレッドにアクセスした時のステータスコードが404か
     def test_thread_view_404(self):
-        # cf. https://docs.djangoproject.com/en/3.2/ref/databases/#storage-engines
         max_id = Thread.objects.all().aggregate(Max("id"))["id__max"]
         response = self.client.get(reverse('threads', args=[max_id+1])) # /threads/2/ にアクセス
         self.assertEqual(response.status_code, 404)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = A_plus_Tsukuba.settings
+python_files = test_*.py
+norecursedirs=.venv


### PR DESCRIPTION
# なぜテストが通らなかったのか
## SQLiteでも発生する問題
#### `DateTimeField`でOrderingを確認するテストについて
 - 原因
   1.  `created_at`カラムを指定しない場合、レコードを`create`すると、`datetime.now`がセットされる。
   2. DBMSにもよるが、時刻を扱うデータは秒単位またはミリ秒単位のことが多い。
   3. コード上でA=>Bの順でレコードを作成しても、AとBの`created_at`が同一値になることがある。
   4. その場合、AとBの`ORDER BY`の結果は不定であり、実行するたびにテストの成否が変わってしまう。
   5. 性能が高いコンピュータほどテストに失敗しやすくなる。遅いPCだと99%通るかも。
 - 解消方法
   1. `setUp`で生成するテストレコードには、`created_at`に過去の日時情報を明示的に指定した。
   2. 時刻による順序が必要な場面では、`datetime.timedelta`を用いて明示的に秒単位以上の時刻差を与えた。
   3. これら明示的に指定した日時はすべて、実行時点で過去の日時となるようにしている。
 ## MariaDBでのみ発生する問題
 #### テストレコードの`Subject.code`が`max_length`制約を満たしていない 
 - 原因
  1. SQLiteでは`max_length`は無視されるため。
  2. `setUp()`等で宣言される`code`が10文字以上。
  - 解消方法
  1. `code`を`TS0001`などわかりやすく、短い形に変更。
 #### `Thread.id`を明示的に指定してはいけない（`/thread/1/`など）
- 原因
 1. `Thread.id`はmodels.pyで宣言されていないため、`AutoFeild`のプライマリキーとなる。
 2. `AutoFeild`はいい感じに連番でidを振ってくれるが、必ずしも"1,2,3..."ではない。

Djangoのテスト仕様は複雑で、各テストケースを実行するたびに`setUp()`後の状態にトランザクションがロールバックされる。この仕様とMySQLのidの振り方（最後に振ったid+1?）が相性が悪いんだと思う。
 - 解消方法
  1. `setUp()`で生成したスレッドを`self.thread`にキャプチャし、各ケースで`self.thread.id`を参照する。

## その他
`python manage.py test`よりも、`pytest`の方がモダンなようなので、pytest用の設定ファイルを作成しています。
```
pip install pytest pytest-django
pytest
```
で動きます。`requirements.txt`は現時点で意味不明なので、そのうち`poetry`でやり直します。(issue #68 )

また、`.vscode/settings.json`に
```
{
    "python.testing.pytestArgs": [
        "."
    ],
    "python.testing.unittestEnabled": false,
    "python.testing.pytestEnabled": true
}
```
と書くと、左側のフラスコから単体テストできます。
![image](https://user-images.githubusercontent.com/40143183/209925532-733ab812-f648-4aac-bbd6-26b241b8c6d5.png)
