### PR TITLE
モーダルを利用した雑談スレッドへの遷移 (related issue #72)

### DIFF
--- a/board/templates/board/Search.html
+++ b/board/templates/board/Search.html
@@ -15,6 +15,101 @@
 </head>
 
 <body class="bg-light">
+  <!-- 雑談スレッドへのモーダル -->
+  <div class="modal fade" id="chatModal" tabindex="-1" aria-labelledby="chatModalLabel" aria-hidden="true">
+    <div class="modal-dialog pt-5">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="chatModalLabel">雑談スレッド</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="戻る"></button>
+        </div>
+        <div class="modal-body">
+          <div class="text-center m-3">
+            <button type="button" class="btn btn-danger"
+              onclick="location.href='https://www.aplus-tsukuba.net/threads/6304/'">
+              🐣新入生雑談スレッド
+            </button><br>
+            ㊗新入生の皆さん、ご入学おめでとうございます🌸
+          </div>
+          学群ごとの雑談スレッド：
+          <ul class="list-group list-group-horizontal">
+            <a href="https://www.aplus-tsukuba.net/threads/6292/" 
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-primary">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">📕人文・文化</div>
+                </div>
+            </a>
+            <a href="https://www.aplus-tsukuba.net/threads/6293/"
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-secondary">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">🌎社会・国際</div>
+                  </div>
+            </a>
+            </ul>
+            <ul class="list-group list-group-horizontal">
+            <a href="https://www.aplus-tsukuba.net/threads/6294/"
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-success">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">👶人間</div>
+                  </div>
+            </a>
+            <a href="https://www.aplus-tsukuba.net/threads/6295/" 
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-danger">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">🧬生命環境</div>
+                  </div>
+            </a>
+            </ul>
+            <ul class="list-group list-group-horizontal">
+            <a href="https://www.aplus-tsukuba.net/threads/6296/"
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-warning">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">🧪 理工</div>
+                  </div>
+            </a>
+            <a href="https://www.aplus-tsukuba.net/threads/6297/"
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-info">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">💻情報</div>
+                  </div>
+            </a>
+          </ul>
+          <ul class="list-group list-group-horizontal">
+            <a href="https://www.aplus-tsukuba.net/threads/6298/"
+                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-light">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">👨‍⚕️医学</div>
+                  </div>
+            </a>
+            <a href="https://www.aplus-tsukuba.net/threads/6299/" 
+               class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-dark">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">💪体育</div>
+                  </div>
+            </a>
+          </ul>
+          <ul class="list-group list-group-horizontal">
+            <a href="https://www.aplus-tsukuba.net/threads/6300/"
+              class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-danger">
+                <div class="ms-2 me-auto">
+                    <div class="fw-bold">🎨芸術</div>
+                  </div>
+            </a>
+            <a href="https://www.aplus-tsukuba.net/threads/6301/" 
+              class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-success">
+              <div class="ms-2 me-auto">
+                  <div class="fw-bold">🫠総合</div>
+                </div>
+          </a>
+          </ul>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">戻る</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   {% include 'header.html' %}
 
   <div id="main_container" class="container-fluid">
@@ -40,34 +135,9 @@
             履修している講義スレッドに参加して、
             <br class="mobile-only">
             協力してA+を目指そう！<br>
-            雑談スレッドは
-            <a class="text-decoration-none" role="button" data-bs-toggle="collapse" data-bs-target="#collapseTalk"
-              aria-expanded="false" aria-controls="collapseExample">
-              こちら
-            </a>
-            <div class="container">
-              <div class="collapse" id="collapseTalk">
-                <div class="card card-body mb-3">
-                  <div class="row">
-                    <div class="col">
-                      <a href="/threads/6292/" class="text-decoration-none me-2 mb-2 color-dark-blue">人文・文化</a>
-                      <a href="/threads/6293/" class="text-decoration-none me-2 mb-2 color-dark-blue">社会・国際</a>
-                      <a href="/threads/6294/" class="text-decoration-none me-2 mb-2 color-dark-blue">人間</a>
-                      <a href="/threads/6295/" class="text-decoration-none me-2 mb-2 color-dark-blue">生命環境</a>
-                      <a href="/threads/6296/" class="text-decoration-none me-2 mb-2 color-dark-blue">理工</a>
-                      <a href="/threads/6297/" class="text-decoration-none me-2 mb-2 color-dark-blue">情報</a>
-                      <a href="/threads/6298/" class="text-decoration-none me-2 mb-2 color-dark-blue">医</a>
-                      <a href="/threads/6299/" class="text-decoration-none me-2 mb-2 color-dark-blue">体育専門</a>
-                      <a href="/threads/6300/" class="text-decoration-none me-2 mb-2 color-dark-blue">芸術専門</a>
-                      <a href="/threads/6301/" class="text-decoration-none me-2 mb-2 color-dark-blue">総合</a>
-                      <a href="/threads/6302/" class="text-decoration-none me-2 mb-2 color-dark-blue">学園祭</a>
-                      <a href="/threads/6304/" class="text-decoration-none me-2 mb-2 color-dark-blue">新入生向け</a>                      
-                      <span class="text-danger">←NEW!</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <button type="button" class="btn btn-info btn-sm" data-bs-toggle="modal" data-bs-target="#chatModal">
+              雑談スレッドはこちら
+            </button>
           </div>
         </div>
       </div>
@@ -395,7 +465,7 @@
     </div>
     {% include 'footer.html' %}
   </div>
-
+  
   {% include 'load_javascript.html' %}
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   <script src="{% static 'board/search.js' %}"></script>

--- a/board/templates/board/Search.html
+++ b/board/templates/board/Search.html
@@ -26,20 +26,20 @@
         <div class="modal-body">
           <div class="text-center m-3">
             <button type="button" class="btn btn-danger"
-              onclick="location.href='https://www.aplus-tsukuba.net/threads/6304/'">
+              onclick="location.href='{% url 'threads' 6304 %}'">
               🐣新入生雑談スレッド
             </button><br>
             ㊗新入生の皆さん、ご入学おめでとうございます🌸
           </div>
           学群ごとの雑談スレッド：
           <ul class="list-group list-group-horizontal">
-            <a href="https://www.aplus-tsukuba.net/threads/6292/" 
+            <a href="{% url 'threads' 6292 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-primary">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">📕人文・文化</div>
                 </div>
             </a>
-            <a href="https://www.aplus-tsukuba.net/threads/6293/"
+            <a href="{% url 'threads' 6293 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-secondary">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">🌎社会・国際</div>
@@ -47,13 +47,13 @@
             </a>
             </ul>
             <ul class="list-group list-group-horizontal">
-            <a href="https://www.aplus-tsukuba.net/threads/6294/"
+            <a href="{% url 'threads' 6294 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-success">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">👶人間</div>
                   </div>
             </a>
-            <a href="https://www.aplus-tsukuba.net/threads/6295/" 
+            <a href="{% url 'threads' 6295 %}" 
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-danger">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">🧬生命環境</div>
@@ -61,13 +61,13 @@
             </a>
             </ul>
             <ul class="list-group list-group-horizontal">
-            <a href="https://www.aplus-tsukuba.net/threads/6296/"
+            <a href="{% url 'threads' 6296 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-warning">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">🧪 理工</div>
                   </div>
             </a>
-            <a href="https://www.aplus-tsukuba.net/threads/6297/"
+            <a href="{% url 'threads' 6297 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-info">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">💻情報</div>
@@ -75,13 +75,13 @@
             </a>
           </ul>
           <ul class="list-group list-group-horizontal">
-            <a href="https://www.aplus-tsukuba.net/threads/6298/"
+            <a href="{% url 'threads' 6298 %}"
                 class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-light">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">👨‍⚕️医学</div>
                   </div>
             </a>
-            <a href="https://www.aplus-tsukuba.net/threads/6299/" 
+            <a href="{% url 'threads' 6299 %}" 
                class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-dark">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">💪体育</div>
@@ -89,13 +89,13 @@
             </a>
           </ul>
           <ul class="list-group list-group-horizontal">
-            <a href="https://www.aplus-tsukuba.net/threads/6300/"
+            <a href="{% url 'threads' 6300 %}"
               class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-danger">
                 <div class="ms-2 me-auto">
                     <div class="fw-bold">🎨芸術</div>
                   </div>
             </a>
-            <a href="https://www.aplus-tsukuba.net/threads/6301/" 
+            <a href="{% url 'threads' 6301 %}" 
               class="list-group-item d-flex list-group-item-action justify-content-between align-items-center list-group-item-success">
               <div class="ms-2 me-auto">
                   <div class="fw-bold">🫠総合</div>
@@ -452,7 +452,7 @@
                       📨<a href="mailto:info@aplus-tsukuba.net">メールでのお問い合わせ</a>
                     </li>
                     <li class="list-group-item">
-                      📋<a href="/threads/6291">運営へのお問い合わせスレッド</a>
+                      📋<a href="{% url 'threads' 6291 %}">運営へのお問い合わせスレッド</a>
                     </li>
                   </ul>
                 </div>


### PR DESCRIPTION
#72 に対応。

モーダル利用して雑談スレッドを見やすくしました。
@nitoca のブランチのデザインも参考にしています。
ローカルで動作OK.

以下スクショ
![image](https://user-images.githubusercontent.com/40143183/219884216-8618f982-a9b9-4128-b95f-053e29b92b4a.png)
![image](https://user-images.githubusercontent.com/40143183/219884231-1067ada9-0987-4ff1-8cb7-61f2a948a760.png)
![image](https://user-images.githubusercontent.com/40143183/219884247-42e4e5fa-3f6b-4857-bc9b-f86dd6a52c00.png)
![image](https://user-images.githubusercontent.com/40143183/219884260-32529fd2-214b-46a9-8af9-8f5b7b0a6bcd.png)

学園祭スレッドは隠してしまっています。やどさいのころに新入生スレッドの強調をやめて二つ並んで出せばいいかな。