### PR TITLE
sqlmodeの設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
    # 文字コード設定とsql_modeをconohaに合わせる 
    # ConoHa DBサーバーではデータベース権限しかもらえない
    # utf8mb4とsql_modeの設定は.env側（django側＝セッションスコープ変数）で行うことで権限不足を回避する
-   command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --sql_mode=""
+   command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --sql_mode="STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
    volumes:
      - data-volume:/var/lib/mysql
    healthcheck:


### PR DESCRIPTION
dockerを停止して、再起動するたびにモードがリセットされてしまうからこっちの方がいいのかな？