### PR TITLE
追加の感情の実装（Backend+Front投稿系+Front表示系)

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -31,6 +31,26 @@ class Post(models.Model):
         (3, "提案(^^)/~~~"),
         (4, "ウンウン(´ー｀*)"),
         (5, "大丈夫？( *´艸｀)"),
+
+        # ランクに応じて追加される感情
+        # Bronze 
+        (10, "ｆｍ(( ˘ω ˘ *))ｆｍ"),
+        (11, "ぴえん🥺"),
+        # Silver
+        (20, "ありがとう🙏"),
+        (21, "そんな……😭"),
+        # Gold
+        (30, "もう無理😖"),
+        (31, "異議ありっ！！"),
+        (32, "🎖️GOLD🎖️"),
+        # Master
+        (40, "完全に理解した！"),
+        (41, "どしたん話聞こか？"),
+        (42, "🎓MASTER🎓"),
+        # Grand Master
+        (50, "IMAGINE THE FUTURE."),
+        (51, "DESIGN THE FUTURE."),
+        (52, "👑GRAND MASTER👑"),
     )
 
     post_id = models.UUIDField(verbose_name='投稿者id', primary_key=True, default=uuid.uuid4, editable=False)

--- a/board/models.py
+++ b/board/models.py
@@ -72,6 +72,26 @@ class Reply(models.Model):
         (3, "提案(^^)/~~~"),
         (4, "ウンウン(´ー｀*)"),
         (5, "大丈夫？( *´艸｀)"),
+
+        # ランクに応じて追加される感情
+        # Bronze 
+        (10, "ｆｍ(( ˘ω ˘ *))ｆｍ"),
+        (11, "ぴえん🥺"),
+        # Silver
+        (20, "ありがとう🙏"),
+        (21, "そんな……😭"),
+        # Gold
+        (30, "もう無理😖"),
+        (31, "異議ありっ！！"),
+        (32, "🎖️GOLD🎖️"),
+        # Master
+        (40, "完全に理解した！"),
+        (41, "どしたん話聞こか？"),
+        (42, "🎓MASTER🎓"),
+        # Grand Master
+        (50, "IMAGINE THE FUTURE."),
+        (51, "DESIGN THE FUTURE."),
+        (52, "👑GRAND MASTER👑"),
     )
 
     post_id = models.ForeignKey(Post, on_delete=models.CASCADE, to_field="post_id")

--- a/board/static/board/chat.css
+++ b/board/static/board/chat.css
@@ -181,3 +181,7 @@
 .bg-tsukuba-itf {
     background-color: #00bfd6;
 }
+
+.bg-tsukuba-gold {
+    background-color: #F8B400;
+}

--- a/board/static/board/chat.css
+++ b/board/static/board/chat.css
@@ -174,3 +174,10 @@
     }
 }
 
+.bg-tsukuba-purple {
+    background-color: #6600cc;
+}
+
+.bg-tsukuba-itf {
+    background-color: #00bfd6;
+}

--- a/board/static/board/col7.js
+++ b/board/static/board/col7.js
@@ -61,7 +61,7 @@ Vue.createApp({
                 21: 'badge rounded-pill bg-primary',
                 30: 'badge rounded-pill bg-gray',
                 31: 'badge rounded-pill bg-danger',
-                32: 'badge rounded-pill bg-success',
+                32: 'badge rounded-pill bg-tsukuba-gold text-light',
                 40: 'badge rounded-pill bg-danger',
                 41: 'badge rounded-pill bg-pink',
                 42: 'badge rounded-pill bg-success',

--- a/board/static/board/col7.js
+++ b/board/static/board/col7.js
@@ -54,6 +54,20 @@ Vue.createApp({
                 3: 'badge rounded-pill bg-primary',
                 4: 'badge rounded-pill bg-gray',
                 5: 'badge rounded-pill bg-orange',
+
+                10: 'badge rounded-pill bg-gray',
+                11: 'badge rounded-pill bg-primary',
+                20: 'badge rounded-pill bg-pink',
+                21: 'badge rounded-pill bg-primary',
+                30: 'badge rounded-pill bg-gray',
+                31: 'badge rounded-pill bg-danger',
+                32: 'badge rounded-pill bg-success',
+                40: 'badge rounded-pill bg-danger',
+                41: 'badge rounded-pill bg-pink',
+                42: 'badge rounded-pill bg-success',
+                50: 'badge rounded-pill bg-tsukuba-itf text-light',
+                51: 'badge rounded-pill bg-tsukuba-purple text-light',
+                52: 'badge rounded-pill bg-dark',
             };
             return emotion_class_dict[emotion_code];
         },
@@ -66,6 +80,20 @@ Vue.createApp({
                 3: '提案(^^)/~~~',
                 4: `ウンウン(´ー｀*)`,
                 5: '大丈夫？( *´艸｀)',
+
+                10: "ｆｍ ˘ω ˘ *))ｆｍ",
+                11: "ぴえん🥺",
+                20: "ありがとう🙏",
+                21: "そんな……😭",
+                30: "もう無理😖",
+                31: "異議ありっ！！",
+                32: "🎖️GOLD🎖️",
+                40: "完全に理解した！",
+                41: "どしたん話聞こか？",
+                42: "🎓MASTER🎓",
+                50: "IMAGINE THE FUTURE.",
+                51: "DESIGN THE FUTURE.",
+                52: "👑GRAND MASTER👑",
             };
             return emotion_text_dict[emotion_code];
         },

--- a/board/static/board/col7.js
+++ b/board/static/board/col7.js
@@ -52,7 +52,7 @@ Vue.createApp({
                 1: 'badge rounded-pill bg-olive',
                 2: 'badge rounded-pill bg-pink',
                 3: 'badge rounded-pill bg-primary',
-                4: `badge rounded-pill bg-gray`,
+                4: 'badge rounded-pill bg-gray',
                 5: 'badge rounded-pill bg-orange',
             };
             return emotion_class_dict[emotion_code];

--- a/board/templates/send.html
+++ b/board/templates/send.html
@@ -25,6 +25,21 @@
           <option value="3">提案(^^)/~~~</option>
           <option value="5">大丈夫？( *´艸｀)</option>
           <option value="4">ウンウン(´ー｀*)</option>
+
+          <!-- Rankによって追加される感情 -->
+          <option value="10">ｆｍ(( ˘ω ˘ *))ｆｍ</option>
+          <option value="11">ぴえん🥺</option>
+          <option value="20">ありがとう🙏</option>
+          <option value="21">そんな……😭</option>
+          <option value="30">もう無理😖</option>
+          <option value="31">異議ありっ！！</option>
+          <option value="32">🎖️GOLD🎖️</option>
+          <option value="40">完全に理解した！</option>
+          <option value="41">どしたん話聞こか？</option>
+          <option value="42">🎓MASTER🎓</option>
+          <option value="50">IMAGINE THE FUTURE.</option>
+          <option value="51">DESIGN THE FUTURE.</option>
+          <option value="52">👑GRAND MASTER👑</option>
         </select>
         本文 :
         <textarea v-model.trim="inputText" class="form-control" rows="15" type="text" autocomplete="off" name="message"


### PR DESCRIPTION
**やったこと**

 - 追加する感情を完全に実装し、投稿=>表示　できるようにした。
 - postの場合とreplyの場合それぞれでローカルで動作を確認した。
  
**やっていないこと**

 - ランクによるdropdownの選択肢の切り替え
 
**変更箇所**

 - Backend
   -  `Posts` `Replys`ともに、modelに`choices`である、`EMOTIONS`に値を追加。追加する感情の実体値を定義。
     - FYI: `EMOTIONS`で定義されていない番号の感情が投稿されると400エラーになります。 
 - Front投稿系
   - dropdownのoptionを追加
 - Front表示系
   - 追加した感情のデザインやテキストをjsに設定
 
**参考画像**
感情バッチのデザイン はこんな感じに設定しました。
https://cdn.discordapp.com/attachments/1024950695171993661/1135277692468600883/image.png

**レビューしてほしいこと**
 - 動作確認
 - 各バッチのデザインが変でないか、このままでいいか？