### PR TITLE
教科書アマゾンアソシエイト＋Prime Student広告実装

### DIFF
--- a/board/admin.py
+++ b/board/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Post, Thread, Reply, Subject, Notice, Review, Tag
+from .models import Post, Thread, Reply, Subject, Notice, Review, Tag, Textbooks
 # Register your models here.
 
 class PostModelAdmin(admin.ModelAdmin):
@@ -47,3 +47,4 @@ admin.site.register(Subject, SubjectModelAdmin)
 admin.site.register(Notice)
 admin.site.register(Review, ReviewModelAdmin)
 admin.site.register(Tag, TagModelAdmin)
+admin.site.register(Textbooks)

--- a/board/models.py
+++ b/board/models.py
@@ -178,5 +178,8 @@ class Textbooks(models.Model):
     ]
     """
 
+    class Meta:
+        verbose_name_plural = "Textbooks"
+
     def __str__(self):
         return self.thread.title + "の教科書情報JSON"

--- a/board/models.py
+++ b/board/models.py
@@ -137,3 +137,46 @@ class Review(models.Model):
 
     def __str__(self):
         return self.thread.title + "のレビュー"
+
+class Textbooks(models.Model):
+    thread = models.ForeignKey(Thread, verbose_name="スレッドid", on_delete=models.CASCADE)
+    textbooks_json_object = models.TextField(verbose_name="教科書情報JSON", blank=True, default="{}")
+
+    """
+    textbooks_json_objectは以下のようなJSONを想定している
+    文字列は本来PythonでUnicodeエスケープされている。
+    例えば、"\\u6559\\u79d1\\u66f8"は"教科書"である。
+    ここでは簡便のため、エスケープせず例を示す。
+
+    4676: データベース概論A
+    {
+    "rows": [
+        {
+            "row": [
+                {
+                    "text": "以下を教科書とする.",
+                    "is_link": false
+                }
+            ]
+        },
+        {
+            "row": [
+                {
+                    "text": "1. 北川博之 「",
+                    "is_link": false
+                },
+                {
+                    "text": "データベースシステム 改訂2版",
+                    "is_link": true
+                },
+                {
+                    "text": "」(オーム社)",
+                    "is_link": false
+                }
+            ]
+        }
+    ]
+    """
+
+    def __str__(self):
+        return self.thread.title + "の教科書情報JSON"

--- a/board/static/board/chat.css
+++ b/board/static/board/chat.css
@@ -185,3 +185,13 @@
 .bg-tsukuba-gold {
     background-color: #F8B400;
 }
+
+.textbook-p {
+    overflow-wrap: anywhere;
+    margin-left: 2em;
+    margin-right: 2em;
+}
+
+.fs-textbook {
+    font-size: 0.8em;
+}

--- a/board/static/board/common.js
+++ b/board/static/board/common.js
@@ -1,9 +1,11 @@
 const BOOK_MARK = {}
 const REVIEWED = {}
 const REV_COUNT = {}
+const PRIME_STUDENT_ALERT = {}
 BOOK_MARK.EXPIRES = 365 * 6; // Bachelor and Master period
 REVIEWED.EXPIRES = 365 * 6; // Bachelor and Master period
 REV_COUNT.EXPIRES = 365 * 6; // Bachelor and Master period
+PRIME_STUDENT_ALERT.EXPIRES = 180; // 6 months
 REV_COUNT.COUNT = 0;
 
 
@@ -74,3 +76,11 @@ REVIEWED.setReviewed = function (thread_id) {
 REV_COUNT.COUNT = Object.keys(
     REVIEWED.getCookies()
 ).length;
+
+PRIME_STUDENT_ALERT.setCookieHide = function () {
+    Cookies.set("prime_student_alert_hide", "true", { expires: PRIME_STUDENT_ALERT.EXPIRES });
+}
+
+PRIME_STUDENT_ALERT.isNotHide = function () {
+    return !Cookies.get("prime_student_alert_hide"); //undefined は !false として扱われる
+}

--- a/board/static/board/textbooks.js
+++ b/board/static/board/textbooks.js
@@ -1,0 +1,21 @@
+Vue.createApp({
+    delimiters: ['[[', ']]'],
+    data() {
+        return {
+            is_not_hide: false,
+        }
+    },
+    methods: {
+        load_is_not_hide() {
+            this.is_not_hide = PRIME_STUDENT_ALERT.isNotHide();
+        },
+        push_hide() {
+            PRIME_STUDENT_ALERT.setCookieHide();
+            this.load_is_not_hide();
+        },
+    },
+    mounted() {
+        this.load_is_not_hide();
+    }
+
+}).mount('#textbooks_app');

--- a/board/templates/board/Chat.html
+++ b/board/templates/board/Chat.html
@@ -36,6 +36,7 @@
   <script src="{% static 'board/share.js' %}"></script>
   <script src="{% static 'board/bookmark_btn.js' %}"></script>
   <script src="{% static 'board/double_post.js' %}"></script>
+  <script src="{% static 'board/textbooks.js' %}"></script>
 </body>
 
 </html>

--- a/board/templates/board/Search.html
+++ b/board/templates/board/Search.html
@@ -474,6 +474,19 @@
                         </svg>
                       </a>
                     </li>
+                    <li class="list-group-item"><a
+                      href="https://aplus-tsukuba.hateblo.jp/entry/2023/09/17/221217"
+                      target="_blank">
+                      🧾アフィリエイト広告について
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                        class="bi bi-box-arrow-up-right" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd"
+                          d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z" />
+                        <path fill-rule="evenodd"
+                          d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z" />
+                      </svg>
+                    </a>
+                    </li>
                   </ul>
                   <br>
                   <h5 class="card-title">開発チーム⚒️</h5>

--- a/board/templates/col5.html
+++ b/board/templates/col5.html
@@ -22,6 +22,9 @@
       </table>
     </div>
   </div>
+
+  {% include 'textbooks.html' %}
+
   {% include 'reviews.html' %}
 
   <div class="row" id="share_app">
@@ -54,10 +57,7 @@
   <div class="row">
     <div class="col text-center ad-box col-lg-8 mx-auto">
       広告<br>
-      <a href="https://github.com/half-blue/A_plus_Tsukuba/wiki/%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B5%E3%83%BC%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6">
-      <img src="{% static 'board/ad.png' %}" alt="ad" class="w-100">
-     </a>
-    </div>
+      <iframe src="https://rcm-fe.amazon-adsystem.com/e/cm?o=9&p=12&l=ur1&category=amazonstudent&banner=1EXM3ZCBAGEJJSPD8ZG2&f=ifr&linkID=f40dcd63042699c6135180322a0b1d6a&t=aplustsukuba-22&tracking_id=aplustsukuba-22" width="300" height="250" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0" sandbox="allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation"></iframe>    </div>
   </div>
   <div class="row">
     <div class="col text-center ad-box col-lg-8 mx-auto">

--- a/board/templates/textbooks.html
+++ b/board/templates/textbooks.html
@@ -5,9 +5,11 @@
             <div class="h5 m-0">教科書情報</div>
             <div class="badge bg-danger ms-1">&#946;版</div>
         </div>
-        <div class="btn btn-warning rounded-pill" data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
-                詳細を見る
-        </div>  
+        <button class="btn dropdown-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+            <span class="text-primary">
+                展開する
+            </span>
+        </button>
     </div>
 
     <div class="collapse" id="collapseExample">
@@ -28,7 +30,7 @@
                 {{ textbooks | safe }}
             </p>
 
-            <p class="textbook-p fs-textbook">※情報が不正確である場合があります。</p>            
+            <p class="textbook-p fs-textbook">※2023年7月時点での情報です。</p>            
         </div>
     </div>
 </div>

--- a/board/templates/textbooks.html
+++ b/board/templates/textbooks.html
@@ -1,24 +1,34 @@
 {% load static %}
-<div v-cloak id="textbooks_app">
-    <div class="d-flex justify-content-start">
-        <div class="h5">教科書</div>
-        <div class="badge bg-danger ms-1 mt-n2 align-self-start">beta</div>
-        <div class="align-self-center small ms-2">(情報が不正確である場合があります。)</div>    
+<div v-cloak id="textbooks_app" class="mb-4">
+    <div class="d-flex justify-content-between me-2">
+        <div class="d-flex align-self-center">
+            <div class="h5 m-0">教科書情報</div>
+            <div class="badge bg-danger ms-1">&#946;版</div>
+        </div>
+        <div class="btn btn-warning rounded-pill" data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+                詳細を見る
+        </div>  
     </div>
 
-    <!-- Prime Student PR -->
-    <div v-if="is_not_hide" class="alert alert-success alert-dismissible fade show d-flex align-items-center mx-1" role="alert">
-        <div class="ms-2 fs-textbook">
-            [PR] <a target="_blank" href="https://www.amazon.co.jp/b?node=2410972051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=410d21f9285ec8d0f154a63354b0f77b&camp=247&creative=1211">Amazon Prime Student</a>
-            は<strong>月額300円（税込）</strong>でプライム会員になれるサービスです。
-            さらに、<strong><a target="_blank" href="https://www.amazon.co.jp/b?ie=UTF8&amp;node=5367902051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=bb287cd2e51a1d24f375c4c400e5e56f&camp=247&creative=1211">
-            クーポンコード「STUBOOK」適用で、書籍3冊同時購入時に10%ポイント還元！</a></strong>
-            お得に教科書を購入したい方は、ぜひご利用ください。
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" v-on:click="push_hide"></button>
+    <div class="collapse" id="collapseExample">
+        <div class="card card-body">
+            <!-- Prime Student PR -->
+            <div v-if="is_not_hide" class="alert alert-success alert-dismissible fade show d-flex align-items-center mx-1" role="alert">
+                <div class="ms-2 fs-textbook">
+                    [PR] <a target="_blank" href="https://www.amazon.co.jp/b?node=2410972051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=410d21f9285ec8d0f154a63354b0f77b&camp=247&creative=1211">Amazon Prime Student</a>
+                    は<strong>月額300円（税込）</strong>でプライム会員になれるサービスです。
+                    さらに、<strong><a target="_blank" href="https://www.amazon.co.jp/b?ie=UTF8&amp;node=5367902051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=bb287cd2e51a1d24f375c4c400e5e56f&camp=247&creative=1211">
+                    クーポンコード「STUBOOK」適用で、書籍3冊同時購入時に10%ポイント還元！</a></strong>
+                    お得に教科書を購入したい方は、ぜひご利用ください。
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" v-on:click="push_hide"></button>
+                </div>
+            </div>
+
+            <p class="textbook-p fs-textbook">
+                {{ textbooks | safe }}
+            </p>
+
+            <p class="textbook-p fs-textbook">※情報が不正確である場合があります。</p>            
         </div>
     </div>
-
-    <p class="textbook-p fs-textbook">
-        {{ textbooks | safe }}
-    </p>
 </div>

--- a/board/templates/textbooks.html
+++ b/board/templates/textbooks.html
@@ -1,0 +1,24 @@
+{% load static %}
+<div v-cloak id="textbooks_app">
+    <div class="d-flex justify-content-start">
+        <div class="h5">教科書</div>
+        <div class="badge bg-danger ms-1 mt-n2 align-self-start">beta</div>
+        <div class="align-self-center small ms-2">(情報が不正確である場合があります。)</div>    
+    </div>
+
+    <!-- Prime Student PR -->
+    <div v-if="is_not_hide" class="alert alert-success alert-dismissible fade show d-flex align-items-center mx-1" role="alert">
+        <div class="ms-2 fs-textbook">
+            [PR] <a target="_blank" href="https://www.amazon.co.jp/b?node=2410972051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=410d21f9285ec8d0f154a63354b0f77b&camp=247&creative=1211">Amazon Prime Student</a>
+            は<strong>月額300円（税込）</strong>でプライム会員になれるサービスです。
+            さらに、<strong><a target="_blank" href="https://www.amazon.co.jp/b?ie=UTF8&amp;node=5367902051&_encoding=UTF8&tag=aplustsukuba-22&linkCode=ur2&linkId=bb287cd2e51a1d24f375c4c400e5e56f&camp=247&creative=1211">
+            クーポンコード「STUBOOK」適用で、書籍3冊同時購入時に10%ポイント還元！</a></strong>
+            お得に教科書を購入したい方は、ぜひご利用ください。
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" v-on:click="push_hide"></button>
+        </div>
+    </div>
+
+    <p class="textbook-p fs-textbook">
+        {{ textbooks | safe }}
+    </p>
+</div>


### PR DESCRIPTION
 ## やったこと
 - 教科書情報をDBから読み取り、リンクを生成して表示する。
 - Prime StudentのAlertを出す、さらに、Cookieで非表示を記録する
 - 広告枠にPrime Studentを貼る
 
## やっていないこと
 - デザインとか
 
## 環境構築方法 (わからなければすぐ聞いてください）
1. `docker exec -it a_plus_tsukuba-web bash`
2. `python manage.py makemaigrations board`
3. `python manage.py migrate`
4. [このスクリプト](https://github.com/half-blue/project-amazons/blob/main/implementation/insert_records.py)を実行してデータを挿入する。当該リポジトリをクローンする必要があります。

