### PR TITLE
コメントする時に感情が全部表示されないバグの修正

### DIFF
--- a/board/static/board/send.js
+++ b/board/static/board/send.js
@@ -67,12 +67,13 @@ Vue.createApp({
         onSendButtonClick() {
             //質問するボタンを押すと呼ばれる
 
-            this.num_of_reviews = REV_COUNT.COUNT;
-
             CHATAPP.reply_to = null;
             window.document.getElementById("allow_tweet_dropdown").style = "";
         },
     },
+    mounted() {
+        this.num_of_reviews = REV_COUNT.COUNT;
+    }
 }).mount('#send_app');
 
 Vue.createApp({


### PR DESCRIPTION
「質問する」時に発火させて、num_of_reveiwsに反映させる方法では「コメントする」で反映しなかったです。
mountedでDOM生成後に一律で発火させる方法に変更しました。