### PR TITLE
科目コードからスレッドにリダイレクトできるようにする

### DIFF
--- a/board/urls.py
+++ b/board/urls.py
@@ -6,6 +6,7 @@ from . import apis
 urlpatterns = [
     path('', views.Index.as_view(), name='index'),
     path('threads/<int:thread_id>/', views.ThreadView.as_view(), name='threads'),
+    path('threads/codes/<slug:subcode>/', views.ThreadViewBySubcode.as_view(), name='subcodes'),
     path('search/', views.SearchView.as_view(), name='search'),
     path('search/new_questions/', views.NewQuestionsView.as_view(), name='new_questions'),
     path('api/get_subthreads', apis.get_subthreads.as_view(), name = "api_get_subthreads"),

--- a/board/views.py
+++ b/board/views.py
@@ -134,8 +134,17 @@ class ThreadView(FormMixin, ListView):
         messages.error(self.request, "レビューの投稿に失敗しました。")
         return response
     
-
-
+class ThreadViewBySubcode(ListView):
+    """科目コードからスレッドにリダイレクトを行う e.g. /threads/codes/GC13201"""
+    def get(self, request, *args, **kwargs):
+        subcode = self.kwargs['subcode']
+        try:
+            # FYI: MySQLでは大文字小文字を区別しない
+            thread_id = Subject.objects.filter(code = subcode).order_by("-year").values("thread_id")[0]["thread_id"]
+        except IndexError:
+            raise Http404()
+        return redirect("threads", thread_id=thread_id)
+        
 
 class AboutView(TemplateView):
     template_name = "board/About.html"


### PR DESCRIPTION
他サービス連携の第一歩として、科目コードからスレッドへのリダイレクトを実装した。

例）
 - http://localhost:8000/threads/codes/GC13201
 - http://localhost:8000/threads/codes/XXX_TALK_G
 - http://localhost:8000/threads/codes/1101102
 - http://localhost:8000/threads/codes/gc13201 (大文字小文字は区別されない）
 - http://localhost:8000/threads/codes/DO_NOT_EXIST (存在しない場合は404が返る）

この機能によって、科目コードという統一IDを使って、A＋つくばにリンクが貼れるようになる。




