### PR TITLE
fix: docker-composeをハイフン無しに。タスクをtools.pyから切り離す。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+docker-compose.override.yml
+
 # Created by https://www.toptal.com/developers/gitignore/api/windows,macos,visualstudiocode,python,django
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos,visualstudiocode,python,django
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Pytest in container...",
             "type": "shell",
-            "command": "python tools/docker.py pytest",
+            "command": "docker exec a_plus_tsukuba-web pytest",
             "problemMatcher": [
                 {
                     "owner": "pytest_docker",
@@ -27,12 +27,15 @@
             "group": {
                 "kind": "test",
                 "isDefault": true
-            }
+            },
+            "dependsOn": [
+                "Build and Run docker a_puls_tsukuba..."
+            ]
         },
         {
             "label": "Build and Run docker a_puls_tsukuba...",
             "type": "shell",
-            "command": "docker-compose up -d --build",
+            "command": "docker compose up -d --build",
             "problemMatcher": [],
             "group": {
                 "kind": "build",
@@ -42,13 +45,16 @@
         {
             "label": "Run the DB container only...",
             "type": "shell",
-            "command": "python tools/docker.py dbonly",
-            "problemMatcher": []
+            "command": "docker stop a_plus_tsukuba-web",
+            "problemMatcher": [],
+            "dependsOn": [
+                "Build and Run docker a_puls_tsukuba..."
+            ]
         },
         {
             "label": "Stop all containers...",
             "type": "shell",
-            "command": "python tools/docker.py stop",
+            "command": "docker stop a_plus_tsukuba-web a_plus_tsukuba-db",
             "problemMatcher": []
         }
     ]

--- a/docker-compose.override.yml.forM1MacUsers
+++ b/docker-compose.override.yml.forM1MacUsers
@@ -1,0 +1,11 @@
+version: '3.8'
+ 
+# docker-compose.override.yml for M1 Macs
+# if you use M1 Macs, you need to use this file.
+# Please rename this file to docker-compose.override.yml
+
+services:
+ my_sql:
+   platform: linux/arm64/v8
+   image: mariadb:10.0.38
+   # the actual VPS DB version is 10.0.33 but this version does not support arm64.

--- a/tools/docker.py
+++ b/tools/docker.py
@@ -1,30 +1,30 @@
-# @nitoca用？便利スクリプト
+# # @nitoca用？便利スクリプト
 
-# 引数がpytestならば関数pytestを実行し、dbonlyならば関数dbonlyを実行する
-import subprocess
-import sys
+# # 引数がpytestならば関数pytestを実行し、dbonlyならば関数dbonlyを実行する
+# import subprocess
+# import sys
 
-def pytest():
-    subprocess.run(["docker", "exec", "a_plus_tsukuba-web", "pytest"])
+# def pytest():
+#     subprocess.run(["docker", "exec", "a_plus_tsukuba-web", "pytest"])
 
-def dbonly():
-    subprocess.run(["docker compose", "up", "-d", "--build"])
-    subprocess.run(["docker", "stop", "a_plus_tsukuba-web"])
+# def dbonly():
+#     subprocess.run(["docker compose", "up", "-d", "--build"])
+#     subprocess.run(["docker", "stop", "a_plus_tsukuba-web"])
 
-def stop():
-    subprocess.run(["docker", "stop", "a_plus_tsukuba-web"])
-    subprocess.run(["docker", "stop", "a_plus_tsukuba-db"])
+# def stop():
+#     subprocess.run(["docker", "stop", "a_plus_tsukuba-web"])
+#     subprocess.run(["docker", "stop", "a_plus_tsukuba-db"])
 
-if __name__ == '__main__':
-    arg = sys.argv[1] if len(sys.argv) > 1 else ""
-    if arg == "pytest" :
-        print("Running pytest IN CONTAINER...")
-        pytest()
-    elif arg == "dbonly" :
-        print("Running the DB CONTAINER ONLY (stop the web container)...")
-        dbonly()
-    elif arg == "stop" :
-        print("Stop containers...")
-        stop()
-    else:
-        print("argument error")
+# if __name__ == '__main__':
+#     arg = sys.argv[1] if len(sys.argv) > 1 else ""
+#     if arg == "pytest" :
+#         print("Running pytest IN CONTAINER...")
+#         pytest()
+#     elif arg == "dbonly" :
+#         print("Running the DB CONTAINER ONLY (stop the web container)...")
+#         dbonly()
+#     elif arg == "stop" :
+#         print("Stop containers...")
+#         stop()
+#     else:
+#         print("argument error")

--- a/tools/docker.py
+++ b/tools/docker.py
@@ -8,7 +8,7 @@ def pytest():
     subprocess.run(["docker", "exec", "a_plus_tsukuba-web", "pytest"])
 
 def dbonly():
-    subprocess.run(["docker-compose", "up", "-d", "--build"])
+    subprocess.run(["docker compose", "up", "-d", "--build"])
     subprocess.run(["docker", "stop", "a_plus_tsukuba-web"])
 
 def stop():


### PR DESCRIPTION
Related #127 

`docker-compose`はすでに非推奨。推奨コマンドは`docker compose`。

`.vscode/task.json`を`tools.py`から独立させた。

@nitoca `tools.py`は（いまだに）要りますか？