### PR TITLE
URLパラメータのpost_idの返信を最初から展開しておく

### DIFF
--- a/board/static/board/col7.js
+++ b/board/static/board/col7.js
@@ -45,18 +45,29 @@ Vue.createApp({
             if (!params.has('post_id')) {
                 return;   
             }
-            let postId = params.get('post_id');
-            // postIdは32文字の16進数であるため、ハイフンを挿入して8-4-4-4-12の形式にする
-            postId = postId.slice(0, 8) + '-' + postId.slice(8, 12) + '-' + postId.slice(12, 16) + '-' + postId.slice(16, 20) + '-' + postId.slice(20);
+            const postId = this.insertHyphenNonSeparateUUID(params.get('post_id'));
             // postIdの接頭辞にpost_boxをつける
-            postId = 'post_box' + postId;
+            const postBoxElementId = 'post_box' + postId;
             if (postId) {
-                const element = document.getElementById(postId);
+                const element = document.getElementById(postBoxElementId);
                 if (element) {
                     element.scrollIntoView({ behavior: 'smooth' });
                     this.scrolledToComment = true; // スクロールしたことを記録
                 }
             }
+        },
+        insertHyphenNonSeparateUUID(non_separate_uuid) {
+          // ハイフンを挿入して8-4-4-4-12の形式にする
+            return non_separate_uuid.slice(0, 8) + '-' + non_separate_uuid.slice(8, 12) + '-' + non_separate_uuid.slice(12, 16) + '-' + non_separate_uuid.slice(16, 20) + '-' + non_separate_uuid.slice(20);  
+        },
+        isThatPostIdScrollTarget(post_id) {
+            //受け取ったpost_idがURLのクエリパラメータのpost_idと一致するかどうかを返す
+            const params = new URLSearchParams(window.location.search);
+            if (!params.has('post_id')) {
+                return false;   
+            }
+            const target_post_id = this.insertHyphenNonSeparateUUID(params.get('post_id'));
+            return post_id === target_post_id;
         },
         formatTimeString(time) {
             //ISO 8601形式のtimeを表示用のテキストに変換する。

--- a/board/templates/col7.html
+++ b/board/templates/col7.html
@@ -104,9 +104,9 @@
             </button>
           </div>
         </div>
-        <!-- 返信の表示 -->
-        <div class="collapse" :id="'reply_box' + st.post_id">
-          <div class="rows">
+        <!-- 返信の表示 URLパラメータのpost_idの返信なら最初から展開しておく-->
+        <div class="collapse" :class="{'show': isThatPostIdScrollTarget(st.post_id)}" :id="'reply_box' + st.post_id">
+          <div v-if="getReplyCount(st.post_id) > 0" class="rows">
             <div class="cols">
               <div v-for="reply in replies[st.post_id]" :key="reply.reply_id">
                 <div class="post_box reply_box">


### PR DESCRIPTION
#143 とは違うアプローチで実装しました。 @nitoca 

`reply_id`には一切対応しておらず、「返信の有無に関係なく、クエリパラメータ`post_id`の`reply_box`に`show`クラスを付与し、最初から展開しておいた状態にする」という実装です。

そのため、返信が存在しない場合はreply_boxの中身を描画しないようにする（今までは表示状態に変更できないだけでＤＯＭには存在していた）という処理も追加しています。

`:class`（`v-bind:class`のalias）の記法については、以下の記事が詳しいです
https://qiita.com/yukiji/items/0e2fcecd6a8f87c280e4
