### PR TITLE
`admin/`のURLを変更する

### DIFF
--- a/A_plus_Tsukuba/urls.py
+++ b/A_plus_Tsukuba/urls.py
@@ -19,6 +19,6 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('kanri/', admin.site.urls),
     path('', include('board.urls')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
セキュリティ対策のため、`admin/`を`kanri/`に変える。

このPRを適用する場合は、供せて以下の変更を行う。

1. Apacheの設定を変更する
　https://github.com/half-blue/A_plus_Tsukuba/wiki/Apache2%E8%A8%AD%E5%AE%9A:-django.conf
　現在、`admin/`を学内限定にしているため、設定を変更するか、限定にする制限を解除する。
2. アクセス制限を開場する場合は、権限が弱いユーザーを作り直し、スーパーユーザーを無効化する。 