### PR TITLE
レビューコメントの最大文字数を100から200に増加  half-blue/A_plus_Tsukuba#162

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -133,7 +133,7 @@ class Review(models.Model):
     ratings_overall = models.IntegerField(choices=RATINGS, verbose_name='総合評価',default=3)
     ratings_easiness = models.IntegerField(choices=RATINGS, verbose_name='楽単度',default=3)
     ratings_content = models.IntegerField(choices=RATINGS, verbose_name='充実度',default=3)
-    comment = models.TextField(verbose_name='コメント', blank=True, max_length=100)
+    comment = models.TextField(verbose_name='コメント', blank=True, max_length=200)
     tags = models.ManyToManyField(Tag, verbose_name='タグ', blank=True)
     created_at = models.DateTimeField(verbose_name='作成日時', default=timezone.now)
 

--- a/board/templates/chat_modals.html
+++ b/board/templates/chat_modals.html
@@ -76,7 +76,7 @@
                         <label for="{{ form.comment.auto_id }}" class="form-label mt-2">コメント（オプション）</label>
                         {{form.comment|add_class:"form-control"|attr:"rows:3"|attr:"v-model.trim:inputComment"}}
                         <div class="text-end">
-                            残り [[ 100 - inputComment.length ]] 文字
+                            残り [[ 200 - inputComment.length ]] 文字
                         </div>
                     </div>
 


### PR DESCRIPTION
※デプロイ時マイグレーションは不要です。

２００文字埋めるとこんな感じ
![image](https://github.com/user-attachments/assets/f00c0556-33d5-41ea-82be-4600ab5c2d99)
長さとしてはこの辺りが限界かも