### PR TITLE
Dockerイメージを作成できるように修正する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Download python image
 # Python version is same as the production.
-FROM python:3.8.10-buster
+FROM python:3.8.20-bullseye
 
 # Cast a spell
 ENV PYTHONUNBUFFERED 1
@@ -14,12 +14,8 @@ RUN apt-get -y install default-mysql-client
 RUN mkdir /a_plus_tsukuba
 
 # Install poerty
-ENV POETRY_HOME=/opt/poetry
-RUN curl -sSL https://install.python-poetry.org | python - && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
-    # venv is not used in the container
+RUN pip install poetry==1.8.2
+RUN poetry config virtualenvs.create false
 
 # Set working dir
 WORKDIR /a_plus_tsukuba

--- a/docker-compose.override.yml.forM1MacUsers
+++ b/docker-compose.override.yml.forM1MacUsers
@@ -1,5 +1,3 @@
-version: '3.8'
- 
 # docker-compose.override.yml for M1 Macs
 # if you use M1 Macs, you need to use this file.
 # Please rename this file to docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
- 
 services:
  my_sql:
    platform: linux/amd64


### PR DESCRIPTION
ゼロからビルドしてみたらうまくいかなくなっていたので修正します。
FCMサーバーの方も修正する必要があるので、そちらのPRも要チェックです。

変更点
 - imageが使用していたdebianのバージョンを上げました。古いバージョンでは`apt update`ができません。
 - poetryのインストールをpip経由に変えました。古いコードだと動きません。
 - `docker-compose.yaml`の`version`は非推奨になったので削除します。